### PR TITLE
(SIMP-764) Update to support multiple releases

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,5 @@
+* Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.1-1
+- Updated to require puppet
+
+* Fri Apr 04 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.1-0
+- Initial Release

--- a/build/pupmod-acpid.spec
+++ b/build/pupmod-acpid.spec
@@ -1,59 +1,102 @@
-Summary: acpid Puppet Module
-Name: pupmod-acpid
+%define module_name acpid
+%define base_name pupmod-%{module_name}
+
+%{lua:
+local variant = rpm.expand("%{_variant}")
+local variant_version = nil
+
+local foo = ""
+
+local i = 0
+for str in string.gmatch(variant,'[^-]+') do
+  if i == 0 then
+    variant = str
+  elseif i == 1 then
+    variant_version = str
+  else
+    break
+  end
+
+  i = i+1
+end
+
+rpm.define("variant " .. variant)
+
+if variant == "pe" then
+  rpm.define("puppet_user pe-puppet")
+else
+  rpm.define("puppet_user puppet")
+end
+
+if variant == "pe" then
+  if variant_version and ( rpm.vercmp(variant_version,'4') >= 0 ) then
+    rpm.define("_sysconfdir /etc/puppetlabs/code")
+  else
+    rpm.define("_sysconfdir /etc/puppetlabs/puppet")
+  end
+elseif variant == "p4" then
+  rpm.define("_sysconfdir /etc/puppetlabs/code")
+else
+  rpm.define("_sysconfdir /etc/puppet")
+end
+}
+
+Summary: %{module_name} Puppet Module
+%if 0%{?_variant:1}
+Name: %{base_name}-%{_variant}
+%else
+Name: %{base_name}
+%endif
+
 Version: 0.0.1
 Release: 1
 License: Apache License, Version 2.0
-Group: Applications/System
-Source: %{name}-%{version}-%{release}.tar.gz
-Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-Buildarch: noarch
-Requires: simp-bootstrap >= 4.2.0
-Requires: puppet
-Obsoletes: pupmod-acpid-test
+Group:     Applications/System
+Source:    %{base_name}-%{version}-%{release}.tar.gz
+BuildRoot: %{_tmppath}/%{base_name}-%{version}-%{release}-buildroot
+BuildArch: noarch
 
-Prefix: /etc/puppet/environments/simp/modules
+%if "%{variant}" == "pe"
+Requires: pe-puppet
+%else
+Requires: puppet
+%endif
+
+Prefix: %{_sysconfdir}/environments/simp/modules
 
 %description
 This puppet module provides the basis for managing the ACPI daemon.
 
 %prep
-%setup -q
+%setup -q -n %{base_name}-%{version}
 
 %build
 
 %install
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
 
-mkdir -p %{buildroot}/%{prefix}/acpid
+mkdir -p %{buildroot}/%{prefix}
 
-dirs='files lib manifests templates'
-for dir in $dirs; do
-  test -d $dir && cp -r $dir %{buildroot}/%{prefix}/acpid
-done
+rm -rf .git
+rm -f *.lock
+rm -rf spec/fixtures/modules
 
+curdir=`pwd`
+dirname=`basename $curdir`
+cp -r ../$dirname %{buildroot}/%{prefix}/%{module_name}
 
 %clean
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
 
-mkdir -p %{buildroot}/%{prefix}/acpid
+mkdir -p %{buildroot}/%{prefix}
 
 %files
-%defattr(0640,root,puppet,0750)
-%{prefix}/acpid
-
-%post
-#!/bin/sh
-
-if [ -d %{prefix}/acpid/plugins ]; then
-  /bin/mv %{prefix}/acpid/plugins %{prefix}/acpid/plugins.bak
-fi
-
-%postun
-# Post uninstall stuff
+%defattr(0640,root,%{puppet_user},0750)
+%{prefix}/%{module_name}
 
 %changelog
-* Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.1-1
-- Updated to require puppet
-
-* Fri Apr 04 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.1-0
-- Initial Release
+%{lua:
+changelog = io.open("CHANGELOG","r")
+io.input(changelog)
+print(io.read("*all"))
+}


### PR DESCRIPTION
Updated the spec file to handle multiple types of Puppet installations.
Requires simp-rake-helpers 1.0.13 to build additional versions.

SIMP-764 #comment First update to multi-version support
