### PR TITLE
(SIMP-811) Fix fatal tar:build hang

### DIFF
--- a/build/pupmod-acpid.spec
+++ b/build/pupmod-acpid.spec
@@ -96,7 +96,9 @@ mkdir -p %{buildroot}/%{prefix}
 
 %changelog
 %{lua:
-changelog = io.open("CHANGELOG","r")
-io.input(changelog)
-print(io.read("*all"))
+changelog = io.open("./CHANGELOG","r")
+if changelog then
+  io.input(changelog)
+  print(io.read("*all"))
+end
 }


### PR DESCRIPTION
Before this commit, the `rake tar:build` task would hang forever.

When `rpm -q --queryformat '%{NAME} %{VERSION} %{RELEASE}\n'`
encountered an unhandled Lua error in %`build/pupmod-acpid.spec` (where
the contents of the file `CHANGELOG` are loaded with `io.load()` using a
relative path) at a point where the `.spec` file is alone in the mock
chroot's `/tmp`, execution would silently drop down to a read() syscall
on stdin and block further execution of the `rpm` command.

This is a more significant problem than it first appears: the hang in
acpid's `tar:build` task also hung SIMP ISO builds.

This patch adds error handling to the `io.read()` call inside
`build/pupmod-acpid.spec`, so Lua will no longer attempt to read from
the file if it has failed to open.

SIMP-811 #close #comment RPM+Lua == ineffable error observables