### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,17 +1,20 @@
 {
-  "name":    "simp-acpid",
-  "version": "0.0.2",
-  "author":  "SIMP Team",
-  "summary": "manages ACPI daemon",
+  "name": "simp-acpid",
+  "version": "0.0.3",
+  "author": "SIMP Team",
+  "summary": "Manages ACPI daemon",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-acpid",
+  "source": "https://github.com/simp/pupmod-simp-acpid",
   "project_page": "https://github.com/simp/pupmod-simp-acpid",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "acpid" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "acpid"
+  ],
   "dependencies": [
     {
-      "name": "simp/simp",
-      "version_requirement": ">= 1.1.0"
+      "name": "simp/simplib",
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-acpid`
SIMP-1618 #close