### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,8 @@
 ---
 fixtures:
   repositories:
-    simp: "https://github.com/simp/pupmod-simp-simp"
+    simp:
+      repo: https://github.com/simp/pupmod-simp-simp
+      branch: 5.X
   symlinks:
     acpid: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in acpid