### PR TITLE
(SIMP-2670) Update invalid dependency boundaries

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,11 +14,11 @@
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 3.2.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` referred to old
versions that would be invalid in SIMP 6.0.0.

This commit resolves the issue by updating the upper and lower
boundaries for each dependency in `metadata.json` to reflect the version
found in SIMP-6.0.0.

SIMP-2670 #comment Fixed `pupmod-simp-acpid`