### PR TITLE
(SIMP-7035) Update to new Travis CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -97,7 +97,7 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      rvm: 2.4.5
+      rvm: 2.4.9
       name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1)'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
@@ -105,7 +105,7 @@ jobs:
 
     - stage: spec
       name: 'Puppet 5.x (Latest)'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
@@ -118,7 +118,7 @@ jobs:
         - bundle exec rake spec
 
     - stage: deploy
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,55 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+# Release       Puppet   Ruby   EOL
+# SIMP 6.4      5.5      2.4    TBD
+# PE 2018.1     5.5      2.4    2020-11 (LTS)
+# PE 2019.2     6.10     2.5    2019-08 (STS)
 #
 # https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
-# ------------------------------------------------------------------------------
-# Release       Puppet   Ruby   EOL
-# PE 2017.3     5.3      2.4.5  2018-12-31
-# SIMP 6.3      5.5      2.4.5  TBD***
-# PE 2018.1     5.5      2.4.5  2020-05 (LTS)***
-# PE 2019.0     6.0      2.5.1  2019-08-31^^^
+# ==============================================================================
 #
-# *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
-
+# Travis CI Repo options for this pipeline:
+#
+#   Travis CI Env Var      Type      Notes
+#   ---------------------  --------  -------------------------------------------
+#   GITHUB_OAUTH_TOKEN     Secure    Required for automated GitHub releases
+#   PUPPETFORGE_API_TOKEN  Secure    Required for automated Forge releases
+#   SKIP_GITHUB_PUBLISH    Optional  Skips publishing GitHub releases if "true"
+#   SKIP_FORGE_PUBLISH     Optional  Skips publishing to Puppet Forge if "true"
+#
+#   The secure env vars will be filtered in Travis CI log output, and aren't
+#   provided to untrusted builds (i.e, triggered by PR from another repository)
+#
+# ------------------------------------------------------------------------------
+#
+# Travis CI Trigger options for this pipeline:
+#
+#   To validate if $GITHUB_OAUTH_TOKEN is able to publish a GitHub release,
+#   trigger a custom Travis CI build for this branch using the CUSTOM CONFIG:
+#
+#     env: VALIDATE_TOKENS=yes
+#
+# ------------------------------------------------------------------------------
+#
+# Release Engineering notes:
+#
+#   To automagically publish a release to GitHub and PuppetForge:
+#
+#   - Set GITHUB_OAUTH_TOKEN and PUPPETFORGE_API_TOKEN as secure env variables
+#     in this repo's Travis CI settings
+#   - Push a git tag that matches the version in the module's `metadata.json`
+#   - The tag SHOULD be annotated with release notes, but nothing enforces this
+#     convention at present
+#
+# ------------------------------------------------------------------------------
 ---
+
 language: ruby
 cache: bundler
-sudo: false
-
-stages:
-  - check
-  - spec
-  - name: deploy
-    if: 'tag IS present'
+version: ~> 1.0
+os: linux
 
 bundler_args: --without development system_tests --path .vendor
 
@@ -35,10 +62,23 @@ addons:
       - rpm
 
 before_install:
+  - for x in ${HOME}/.rvm/gems/*; do gem uninstall -I -x -i "${x}" -v '>= 1.17' bundler || true; gem uninstall -I -x -i "${x}@global" -v '>= 1.17' bundler || true; done
+  - gem install -v '~> 1.17' bundler
   - rm -f Gemfile.lock
 
-global:
-  - STRICT_VARIABLES=yes
+env:
+  global:
+    - 'FORGE_USER_AGENT="TravisCI-ForgeReleng-Script/0.3.3 (Purpose/forge-ops-for-${TRAVIS_REPO_SLUG})"'
+
+stages:
+  - name: 'validate tokens'
+    if: 'env(VALIDATE_TOKENS) = yes'
+  - name: check
+    if: 'NOT env(VALIDATE_TOKENS) = yes'
+  - name: spec
+    if: 'NOT env(VALIDATE_TOKENS) = yes'
+  - name: deploy
+    if: 'tag IS present AND NOT env(VALIDATE_TOKENS) = yes'
 
 jobs:
   include:
@@ -57,52 +97,70 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      name: 'Puppet 5.3 (PE 2017.3)'
       rvm: 2.4.5
-      env: PUPPET_VERSION="~> 5.3.0"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
-      rvm: 2.4.5
-      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1)'
+      name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1)'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      name: 'Latest Puppet 5.x'
+      name: 'Puppet 5.x (Latest)'
       rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      name: 'Latest Puppet 6.x'
-      rvm: 2.5.1
-      env: PUPPET_VERSION="~> 6.0"
+      name: 'Puppet 6.10 (PE 2019.2)'
+      rvm: 2.5.7
+      env: PUPPET_VERSION="~> 6.10.0"
       script:
         - bundle exec rake spec
 
     - stage: deploy
       rvm: 2.4.5
+      env: PUPPET_VERSION="~> 5.5.0"
       script:
         - true
       before_deploy:
         - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+        - '[[ $TRAVIS_TAG =~ ^poxvup-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+        - 'gem install -v "~> 5.5.0" puppet'
+        - 'git clean -f -x -d'
+        - 'puppet module build'
+        - 'find pkg -name ''*.tar.gz'''
       deploy:
-        - provider: releases
-          api_key:
-              secure: "LkPgCyPkenRqkuOWdZOkVKu8jIfWcVSknF+HJUOr+B8r6tV0FdWQPgpb6h6T4ll/kjA7y+/y0aMkvPRpsGecxVEdC7y0MOgk+WFuG24BwF+xTtEGlYtqK/2LwSqoJ8Cw98L6qtWsncbWn4Zn2kyiaQnqOC36BDQTsfLY/Z+BoABmi334Hz06SXEHFjxECFw/R38ngUoHaoimdu1JeXybyqIFneoq0WOiv5o+9yQIAx4tBAPMS17SlQxAZbf5b/zz6KGzvnykvFeLu+hMyf5+fsAaOs13ImhUhbIEtZpu9+e5aHFt5RvtDjIrVXqAF3/+Tk35JDwR9tYKS+KPXjaGeXgwOmhMeJf52sJm6GRwajldh4tpJQNCoCCHUtEh+BR39KfYyu+2FUhETffy3isYzc1+BZzddGpwKOlEiD/2GKSoxQ2ILBEhW77Y1viDj8IMsE4PX40DPtE5F9+8JCT0KDHvQoLLgRktuO1d7bgJX1vbaEPH6y8t5V06dLHyjNa+bBUS4IcvNk+8km2bjtxsIp4o8dKG6QH5xvCUIL5SaUPZHrrykBTrTlWBvNrmx7iQt6oSA3arLEIw5y/GG5HMPieUSgNTWemCEL0KbvtJlRXFHwK6TAQmHsfkzcnUu2Raa4lIdITxTtJXVfW/t5HIqRfo/75OeGJvXX3vfDbJQ8k="
+        - provider: script
           skip_cleanup: true
+          script: 'curl -sS --fail -A "$FORGE_USER_AGENT" -H "Authorization: Bearer ${PUPPETFORGE_API_TOKEN}" -X POST -F "file=@$(find $PWD/pkg -name ''*.tar.gz'')" https://forgeapi.puppet.com/v3/releases'
           on:
             tags: true
             condition: '($SKIP_FORGE_PUBLISH != true)'
-        - provider: puppetforge
-          user: simp
-          password:
-              secure: "Aot/K7XOtHR9B4hAGHtXDH70oGtBuxw64MVW1YOwc7fn2QRcHwZl5spQXVkggZFsUNczzvRD4AW5pAw4DyxssDj3gTVcZz3hdg5CphPBdVqZuOaTjc5TOkC275jxDVlNDbCz0o5Y4WijNFmmdCRwtqKUDRQvb0QbRDLNqiOEf9Ev92iWFmYQPGkqCfW3jZivpIAyDvyyvzLtBfSCrwyIfX2Ex6aX9mtJ1do+wBfHGpSDguQEdDJqa0a6gjFLdc0+y1b6g6UePTqTQseDKpEc8mPr+fAsl16pj1jXPXZ4w945Id63/ntRdLSw2w3nTZJAXVk5jRmwcDdLsq5ueFKM5WjOGA91OwLIcsy3RMT55AdTLIITkdXFzFAjgei3tWRkSFsUQN9tSBAt9kuXc/xiJ4KQOkq9nrPLNZkxH8tVaucdKHQh1Syj5yS5UGxW1tV2Kg9yuixXbhYE/XbTfU7CrUkdxZyJ43nJ4OCTRlhZWH8xz1ZrnUkniK+P11QpElZWZPDhOh3Korgg/eHKSW/UlZesZeVJk3Xnetzn6wONZSS3XlNfUsa/3XVdr5EBS2gXE3LoQhIzS3K5SbXPGfFRryPCAHSrCpzvTcRQ4PUu/LOgKwck0c9ohSBh/aAFHY+J+6T6J7to4SgVlPeqMC27xsysp57WZyssMQifZlIOKKs="
+        - provider: releases
+          token: $GITHUB_OAUTH_TOKEN
           on:
             tags: true
-            condition: '($SKIP_FORGE_PUBLISH != true)'
+            condition: '($SKIP_GITHUB_PUBLISH != true)'
+
+    - stage: 'validate tokens'
+      language: shell
+      before_install: skip
+      install: skip
+      name:  'validate CI GitHub OAuth token has sufficient scope to release'
+      script:
+      - 'echo; echo "===== GITHUB_OAUTH_TOKEN validation";echo "  (TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS)"; echo'
+      - 'OWNER="$(echo $TRAVIS_REPO_SLUG | cut -d/ -f1)"'
+      - 'curl -H "Authorization: token ${GITHUB_OAUTH_TOKEN}"
+          "https://api.github.com/users/$OWNER"
+          -I | grep ^X-OAuth-Scopes | egrep -w "repo|public_repo"'
+
+    - stage: 'validate tokens'
+      name:  'validate CI Puppet Forge token authenticates with API'
+      language: shell
+      before_install: skip
+      install: skip
+      script:
+      - 'echo; echo "===== PUPPETFORGE_API_TOKEN validation"; echo "  (TRAVIS_SECURE_ENV_VARS=$TRAVIS_SECURE_ENV_VARS)"; echo'
+      - 'curl -sS --fail -A "$FORGE_USER_AGENT"
+         -H "Authorization: Bearer ${PUPPETFORGE_API_TOKEN:-default_content_to_cause_401_response}"
+         https://forgeapi.puppet.com/v3/users > /dev/null'


### PR DESCRIPTION
This patch updates the Travis Pipeline to a static, standardized format
that uses project variables for secrets.  It includes an optional
diagnostic mode to test the project's variables against their respective
deployment APIs (GitHub and Puppet Forge).

SIMP-7035 #comment Add new pipeline to pupmod-simp-acpid