### PR TITLE
[puppetsync] Updates for Puppet 8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Oct 23 2023 Steven Pritchard <steve@sicura.us> - 1.7.0
+- [puppetsync] Add EL9 support
+
 * Wed Oct 11 2023 Steven Pritchard <steve@sicura.us> - 1.6.0
 - [puppetsync] Updates for Puppet 8
   - These updates may include the following:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-acpid",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": "SIMP Team",
   "summary": "Manages ACPI daemon",
   "license": "Apache-2.0",
@@ -32,33 +32,38 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     }
   ],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,7 +92,7 @@ RSpec.configure do |c|
   c.mock_with :mocha
 
   c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir)
+  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir) if c.respond_to?(:manifest_dir)
 
   c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
 


### PR DESCRIPTION
These updates may include the following:
* Update Gemfile
* Add support for Puppet 8
* Drop support for Puppet 6
* Update module dependencies