### PR TITLE
Add AGENTS.md and harden rspec/acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,21 @@ dist
 /log
 /doc
 /Gemfile.lock
+
+## AI coding assistant-specific configuration
+## The standard is AGENTS.md
+# Claude Code
+/CLAUDE.md
+/.claude/
+# GitHub Copilot
+/.github/copilot-instructions.md
+# Cursor
+/.cursor/
+/.cursorrules
+# Windsurf
+/.windsurf/
+/.windsurfrules
+# Gemini CLI
+/GEMINI.md
+# Cline
+/.clinerules/

--- a/.pdkignore
+++ b/.pdkignore
@@ -55,3 +55,4 @@
 /spec/
 /.vscode/
 /tests/
+/AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in this repository.
+
+## What this module does
+
+`pupmod-simp-acpid` is a SIMP Puppet module that manages the ACPI event daemon
+(`acpid`) on Enterprise Linux systems. It is intentionally small: a single class
+that installs the `acpid` package and keeps the `acpid` service enabled and
+running.
+
+### Business logic
+
+All behavior lives in the one class, `acpid` (`manifests/init.pp`):
+
+- **`$ensure`** (`String`, default `simplib::lookup('simp_options::package_ensure',
+  { 'default_value' => 'installed' })`) — the package state for `acpid`. It follows
+  the standard SIMP pattern of deferring to the site-wide `simp_options::package_ensure`
+  hiera key when set, falling back to `installed` otherwise. Set it to e.g. `latest`
+  to track updates.
+- Declares `package { 'acpid': ensure => $ensure }`.
+- Declares `service { 'acpid' }` as `ensure => running`, `enable => true`,
+  `hasstatus`/`hasrestart => true`, and `require => Package['acpid']` — so the
+  service is only managed after the package is present.
+
+There are no other classes, defined types, facts, functions, or templates. The
+module has no conditional OS logic in the manifest; OS coverage comes from
+`metadata.json` (EL8–10 across RedHat/CentOS/Oracle/Rocky/Alma) and the acceptance
+node sets.
+
+**Known constraint (from `manifests/init.pp`):** `acpid` is *not* compatible with
+GFS2 and must not be included alongside it — the two subsystems deliberately
+conflict.
+
+## Dependencies
+
+- `simp/simplib` (`>= 4.9.0 < 6.0.0`) — provides `simplib::lookup`.
+- `puppetlabs/stdlib` (`>= 8.0.0 < 10.0.0`).
+- Runtime: `openvox >= 8.0.0 < 9.0.0` (see `metadata.json` `requirements`).
+
+## Repository layout
+
+- `manifests/init.pp` — the entire module (class `acpid`).
+- `spec/classes/init_spec.rb` — rspec-puppet unit tests.
+- `spec/acceptance/suites/default/` — beaker acceptance suite; `nodesets/` holds
+  the per-OS Vagrant/libvirt node definitions.
+- `REFERENCE.md` — generated Puppet Strings reference (do not hand-edit; regenerate).
+- `metadata.json` — module metadata, dependencies, and supported OS matrix.
+
+## Common commands
+
+This module currently uses `puppetlabs_spec_helper` + `simp-rake-helpers (~> 5)`
++ `simp-beaker-helpers (~> 2)`; tasks come from `Simp::Rake::Pupmod::Helpers`
+(see `Rakefile`).
+
+```sh
+bundle install
+
+# Unit tests (rspec-puppet)
+bundle exec rake spec
+
+# Lint / style
+bundle exec rake lint
+bundle exec rake rubocop
+
+# Regenerate REFERENCE.md after changing manifest docstrings
+bundle exec puppet strings generate --format markdown --out REFERENCE.md
+
+# Acceptance tests (beaker; needs a hypervisor — CI uses vagrant_libvirt)
+bundle exec rake beaker:suites[default]
+# or a specific node set:
+bundle exec rake beaker:suites[default,el9]
+```
+
+Note `.rspec` sets `--fail-fast`, so `rake spec` stops at the first failure.
+
+## Conventions
+
+- This is a component of the SIMP ecosystem. Follow SIMP module conventions:
+  parameters that reflect site-wide policy are resolved through
+  `simp_options::*` hiera keys via `simplib::lookup`, defaulting to safe values
+  so the module works standalone.
+- Keep manifest parameter `@param` docstrings current — `REFERENCE.md` is
+  generated from them.

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -20,6 +20,14 @@ describe 'acpid class' do
         apply_manifest(manifest, { catch_changes: true })
       end
 
+      # With the module already applied (and no module-specific facts set), a
+      # noop run must report no pending changes. This is the meaningful noop
+      # assertion: it proves the module is idempotent under noop rather than
+      # merely that the catalog compiles (which the real apply above covers).
+      it 'reports no changes when run in noop mode after convergence' do
+        apply_manifest(manifest, catch_changes: true, noop: true)
+      end
+
       describe package('acpid') do
         it { is_expected.to be_installed }
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe 'acpid' do
   on_supported_os.each do |os, os_facts|
+    # Only base OS facts are provided (no module-specific facts), so these
+    # examples also prove the module compiles cleanly with nothing extra set.
     let(:facts) { os_facts }
 
     context "on #{os}" do
-      it { is_expected.to compile.with_all_deps }
-      it { is_expected.to create_class('acpid') }
-
-      context 'base' do
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('acpid') }
         it { is_expected.to contain_package('acpid').with(ensure: 'installed') }
         it { is_expected.to contain_service('acpid').that_requires('Package[acpid]') }
         it do
@@ -20,6 +21,25 @@ describe 'acpid' do
               hasrestart: true,
             )
         end
+      end
+
+      context 'with a non-default $ensure' do
+        let(:params) { { ensure: 'latest' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_package('acpid').with(ensure: 'latest') }
+      end
+
+      # Exercises the actual SIMP business logic: with no parameter passed,
+      # $ensure resolves via simplib::lookup('simp_options::package_ensure').
+      # The hieradata fixture sets it to a value distinct from the default so a
+      # pass proves the lookup path (not the default) supplied it.
+      # See spec/fixtures/hieradata/package_ensure.yaml.
+      context 'with simp_options::package_ensure set in hiera' do
+        let(:hieradata) { 'package_ensure' }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_package('acpid').with(ensure: '2.0.0') }
       end
     end
   end

--- a/spec/fixtures/hieradata/package_ensure.yaml
+++ b/spec/fixtures/hieradata/package_ensure.yaml
@@ -1,0 +1,5 @@
+---
+# Exercises the simplib::lookup('simp_options::package_ensure', ...) fallback
+# in manifests/init.pp. The value is deliberately distinct from the class
+# default ('installed') so the test proves the lookup path resolved it.
+simp_options::package_ensure: '2.0.0'


### PR DESCRIPTION
## What & why

This is the first module in a cross-org rollout applying five modernization action items to the SIMP community modules. It covers **pupmod-simp-acpid**.

### 1. AI-agent orientation file (`AGENTS.md`)
- Adds `AGENTS.md` documenting the module's business logic (the single `acpid` class, the `simp_options::package_ensure` lookup, and the package + service resources).
- `CLAUDE.md` is a symlink → `AGENTS.md` (kept out of the repo via `.gitignore`; `AGENTS.md` is the canonical file).
- Adds the standard AI-assistant block to `.gitignore` and `/AGENTS.md` to `.pdkignore` (so it isn't packaged into the Forge tarball).

### 2 & 3. Business-logic docs + rspec review
- Business logic is now documented in `AGENTS.md`.
- Reviewed the existing rspec suite: coverage was adequate for the resources but **did not exercise the module's one piece of real business logic** — the `simp_options::package_ensure` lookup. See below.

### 4. rspec additions
- **`with a non-default $ensure`** — passes `ensure => 'latest'` and asserts it reaches the package.
- **`with simp_options::package_ensure set in hiera`** — sets the site-wide hiera key (via a new `spec/fixtures/hieradata/package_ensure.yaml` fixture) to a value distinct from the class default, proving the `simplib::lookup` path (not the default) supplies the value. This is the meaningful "applies cleanly with no module-specific facts set" case at the unit level.
- The per-OS contexts continue to provide only base OS facts, so every example also proves the module compiles cleanly with nothing extra set.

### 5. Acceptance additions
- Added a **post-convergence noop run** (`catch_changes: true, noop: true`) asserting no pending changes. This is the meaningful noop assertion (noop is an apply-time concern, not expressible at the compile-only unit level).

## Testing
- Unit: **126 examples, 0 failures**; rubocop clean. Run in the sicura-nx `puppet-module` devcontainer (Fedora 42 / Ruby 3.4 / openvox 8).
- Acceptance: syntax-checked locally; the beaker suite runs in CI (needs a hypervisor).

## Notes for reviewers
- The `spec/fixtures/hieradata/package_ensure.yaml` fixture is force-added because the puppetsync-maintained `.gitignore` excludes `/spec/fixtures/*` and the re-inclusion negation can't reach it (parent dir excluded). Sibling modules force-add their fixtures the same way.
- No changes to `manifests/`, `metadata.json`, or the puppetsync-managed `.gitignore` ignore rules (only appended the AI-assistant block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
