### PR TITLE
Harden rspec coverage of the package_ensure lookup

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -41,6 +41,19 @@ describe 'acpid' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_package('acpid').with(ensure: '2.0.0') }
       end
+
+      # Unit-level analog of the acceptance "noop from a clean state" test.
+      # rspec-puppet compiles the catalog rather than applying it, so there is
+      # no runtime --noop to exercise here; the meaningful unit assertion is
+      # that the module's removal path is expressible -- with the package
+      # explicitly removed, the catalog sets Package[acpid] to absent and still
+      # compiles with all dependencies.
+      context 'with the package removed ($ensure => absent)' do
+        let(:params) { { ensure: 'absent' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_package('acpid').with(ensure: 'absent') }
+      end
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe 'acpid' do
   on_supported_os.each do |os, os_facts|
+    # Only base OS facts are provided (no module-specific facts), so these
+    # examples also prove the module compiles cleanly with nothing extra set.
     let(:facts) { os_facts }
 
     context "on #{os}" do
-      it { is_expected.to compile.with_all_deps }
-      it { is_expected.to create_class('acpid') }
-
-      context 'base' do
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('acpid') }
         it { is_expected.to contain_package('acpid').with(ensure: 'installed') }
         it { is_expected.to contain_service('acpid').that_requires('Package[acpid]') }
         it do
@@ -20,6 +21,25 @@ describe 'acpid' do
               hasrestart: true,
             )
         end
+      end
+
+      context 'with a non-default $ensure' do
+        let(:params) { { ensure: 'latest' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_package('acpid').with(ensure: 'latest') }
+      end
+
+      # Exercises the actual SIMP business logic: with no parameter passed,
+      # $ensure resolves via simplib::lookup('simp_options::package_ensure').
+      # The hieradata fixture sets it to a value distinct from the default so a
+      # pass proves the lookup path (not the default) supplied it.
+      # See spec/fixtures/hieradata/package_ensure.yaml.
+      context 'with simp_options::package_ensure set in hiera' do
+        let(:hieradata) { 'package_ensure' }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_package('acpid').with(ensure: '2.0.0') }
       end
     end
   end

--- a/spec/fixtures/hieradata/package_ensure.yaml
+++ b/spec/fixtures/hieradata/package_ensure.yaml
@@ -1,0 +1,5 @@
+---
+# Exercises the simplib::lookup('simp_options::package_ensure', ...) fallback
+# in manifests/init.pp. The value is deliberately distinct from the class
+# default ('installed') so the test proves the lookup path resolved it.
+simp_options::package_ensure: '2.0.0'


### PR DESCRIPTION
Unit-test hardening, split out of the original combined PR #114 per review feedback.

- Adds a non-default `$ensure` context.
- Adds a `simp_options::package_ensure` hiera-lookup context (with fixture) that exercises the `simplib::lookup` fallback — the module's real business logic, previously untested.

Branches off `master` and is independent of the AGENTS.md and acceptance PRs (linked below); mergeable in any order.


## Related PRs (split from #114)
- AGENTS.md config: #115
- rspec coverage: #116
- acceptance noop test: #117