### PR TITLE
Add a clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -11,14 +11,14 @@ describe 'acpid class' do
 
   hosts.each do |host|
     context "on #{host}" do
-      # Exercise noop from a clean (uninstalled) state. Running noop *before*
-      # the module is applied is the meaningful assertion: it proves the module
-      # reports its intended changes without enacting them. (A noop run after
-      # convergence only re-proves idempotence, which the real apply below
-      # already covers.)
+      # Exercise noop behavior and noop idempotency:
+      # - From a clean state, noop should report intended changes without enacting them.
+      # - After a real apply, a noop run with `catch_changes: true` should report no pending changes.
+      # This guards against resources that behave differently under noop.
+      #
       context 'in noop mode from a clean state' do
         it 'removes the package so the run starts clean' do
-          on(host, 'puppet resource package acpid ensure=absent')
+          on(host, 'puppet resource package acpid ensure=absent', acceptable_exit_codes: [0, 2])
         end
 
         it 'applies without errors in noop mode' do
@@ -39,7 +39,11 @@ describe 'acpid class' do
         end
 
         it 'is idempotent' do
-          apply_manifest(manifest, { catch_changes: true })
+          apply_manifest(manifest, catch_changes: true)
+        end
+
+        it 'has no pending changes in noop mode' do
+          apply_manifest(manifest, catch_changes: true, noop: true)
         end
 
         describe package('acpid') do

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -11,14 +11,21 @@ describe 'acpid class' do
 
   hosts.each do |host|
     context "on #{host}" do
-      # Exercise noop behavior and noop idempotency:
-      # - From a clean state, noop should report intended changes without enacting them.
-      # - After a real apply, a noop run with `catch_changes: true` should report no pending changes.
-      # This guards against resources that behave differently under noop.
-      #
+      # Exercise noop from a clean (uninstalled) state: a noop apply should
+      # report the module's intended changes without enacting them, so the
+      # package must remain absent afterward. Real idempotence is covered by
+      # the apply below. A *post-convergence* noop check is deliberately
+      # omitted: `puppet apply --noop --detailed-exitcodes` always exits 0
+      # regardless of pending changes, so a catch_changes+noop assertion can
+      # never fail and would test nothing.
       context 'in noop mode from a clean state' do
-        it 'removes the package so the run starts clean' do
-          on(host, 'puppet resource package acpid ensure=absent', acceptable_exit_codes: [0, 2])
+        # Setup, not an assertion: a failure here should error the context
+        # rather than abort the suite under --fail-fast. `puppet resource`
+        # exits 0 whether it removes the package or finds it already absent
+        # (it does not use --detailed-exitcodes), so no acceptable_exit_codes
+        # override is needed.
+        before(:context) do
+          on(host, 'puppet resource package acpid ensure=absent')
         end
 
         it 'applies without errors in noop mode' do
@@ -40,10 +47,6 @@ describe 'acpid class' do
 
         it 'is idempotent' do
           apply_manifest(manifest, catch_changes: true)
-        end
-
-        it 'has no pending changes in noop mode' do
-          apply_manifest(manifest, catch_changes: true, noop: true)
         end
 
         describe package('acpid') do

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -11,22 +11,45 @@ describe 'acpid class' do
 
   hosts.each do |host|
     context "on #{host}" do
-      # Using puppet_apply as a helper
-      it 'works with no errors' do
-        apply_manifest(manifest, catch_failures: true)
+      # Exercise noop from a clean (uninstalled) state. Running noop *before*
+      # the module is applied is the meaningful assertion: it proves the module
+      # reports its intended changes without enacting them. (A noop run after
+      # convergence only re-proves idempotence, which the real apply below
+      # already covers.)
+      context 'in noop mode from a clean state' do
+        it 'removes the package so the run starts clean' do
+          on(host, 'puppet resource package acpid ensure=absent')
+        end
+
+        it 'applies without errors in noop mode' do
+          apply_manifest(manifest, catch_failures: true, noop: true)
+        end
+
+        describe package('acpid') do
+          it 'is not installed by the noop run' do
+            is_expected.not_to be_installed
+          end
+        end
       end
 
-      it 'is idempotent' do
-        apply_manifest(manifest, { catch_changes: true })
-      end
+      context 'when applied' do
+        # Using puppet_apply as a helper
+        it 'works with no errors' do
+          apply_manifest(manifest, catch_failures: true)
+        end
 
-      describe package('acpid') do
-        it { is_expected.to be_installed }
-      end
+        it 'is idempotent' do
+          apply_manifest(manifest, { catch_changes: true })
+        end
 
-      describe service('acpid') do
-        it { is_expected.to be_enabled }
-        it { is_expected.to be_running }
+        describe package('acpid') do
+          it { is_expected.to be_installed }
+        end
+
+        describe service('acpid') do
+          it { is_expected.to be_enabled }
+          it { is_expected.to be_running }
+        end
       end
     end
   end


### PR DESCRIPTION
Acceptance-suite hardening, split out of the original combined PR #114 per review feedback.

Adds a **clean-state noop** acceptance test. The package is removed first (`puppet resource package acpid ensure=absent` in a `before(:context)` hook), then the module is applied with `apply_manifest(manifest, catch_failures: true, noop: true)` and the package is asserted to remain **absent** — verifying that a noop run reports the module's intended changes without enacting them. Existing real-apply, idempotence, and service coverage are preserved under a `when applied` context.

A *post-convergence* noop check (`catch_changes: true, noop: true`) is deliberately **not** included: `puppet apply --noop --detailed-exitcodes` always exits 0 regardless of pending changes, so such an assertion can never fail and would test nothing.

Branches off `master` and is independent of the AGENTS.md and rspec PRs (linked below); mergeable in any order.


## Related PRs (split from #114)
- AGENTS.md config: #115
- rspec coverage: #116
- acceptance noop test: #117
